### PR TITLE
Use dictionary key for goal amount assignment

### DIFF
--- a/lifelog/ui_views/trackers_ui.py
+++ b/lifelog/ui_views/trackers_ui.py
@@ -625,7 +625,7 @@ def create_goal_interactive_tui(stdscr, tracker_type: str):
 
     # 4. Additional fields by goal kind
     if kind == GoalKind.BOOL.value:
-        goal.amount = True
+        goal["amount"] = True
 
     elif kind == GoalKind.RANGE.value:
         min_amt = popup_input(stdscr, "Minimum value:")
@@ -643,7 +643,7 @@ def create_goal_interactive_tui(stdscr, tracker_type: str):
             stdscr, "Number of replacements to target (default 1):")
         goal["old_behavior"] = old
         goal["new_behavior"] = new
-        goal.amount = float(amt) if amt else 1
+        goal["amount"] = float(amt) if amt else 1
 
     elif kind == GoalKind.PERCENTAGE.value:
         target_pct = popup_input(stdscr, "Target percentage (0-100):")
@@ -668,14 +668,14 @@ def create_goal_interactive_tui(stdscr, tracker_type: str):
         amt = popup_input(stdscr, "Target duration amount (number):")
         unit = popup_input(
             stdscr, "Time unit (e.g. minutes, hours):", max_length=20) or "minutes"
-        goal.amount = float(amt) if amt else 0
+        goal["amount"] = float(amt) if amt else 0
         goal["unit"] = unit
 
     elif kind in [GoalKind.SUM.value, GoalKind.COUNT.value, GoalKind.REDUCTION.value]:
         amt = popup_input(stdscr, "Target amount:")
         unit = popup_input(
             stdscr, "Unit (e.g. 'oz', 'times', leave blank if none):", max_length=20) or ""
-        goal.amount = float(amt) if amt else 0
+        goal["amount"] = float(amt) if amt else 0
         goal["unit"] = unit
 
     # For other goal types, add logic as needed.

--- a/lifelog/utils/goal_util.py
+++ b/lifelog/utils/goal_util.py
@@ -126,7 +126,7 @@ def create_goal_interactive(type: str) -> Dict[str, Any]:
 
     # Additional fields based on goal kind
     if goal_kind == GoalKind.BOOL:
-        goal.amount = True
+        goal["amount"] = True
     elif goal_kind == GoalKind.RANGE:
         goal["min_amount"] = float(typer.prompt(
             "Enter minimum value", type=float))
@@ -137,7 +137,7 @@ def create_goal_interactive(type: str) -> Dict[str, Any]:
     elif goal_kind == GoalKind.REPLACEMENT:
         goal["old_behavior"] = typer.prompt("Enter behavior to replace")
         goal["new_behavior"] = typer.prompt("Enter replacement behavior")
-        goal.amount = True
+        goal["amount"] = True
     elif goal_kind == GoalKind.PERCENTAGE:
         goal["target_percentage"] = float(typer.prompt(
             "Enter target percentage (0-100)", type=float))
@@ -153,12 +153,12 @@ def create_goal_interactive(type: str) -> Dict[str, Any]:
         goal["target_streak"] = int(typer.prompt(
             "Enter target streak length", type=int))
     elif goal_kind == GoalKind.DURATION:
-        goal.amount = float(typer.prompt(
+        goal["amount"] = float(typer.prompt(
             "Enter duration amount", type=float))
         goal["unit"] = typer.prompt(
             "Enter time unit (e.g., 'minutes', 'hours')", default="minutes")
     elif goal_kind in [GoalKind.SUM, GoalKind.COUNT, GoalKind.REDUCTION]:
-        goal.amount = float(typer.prompt("Enter target amount", type=float))
+        goal["amount"] = float(typer.prompt("Enter target amount", type=float))
         goal["unit"] = typer.prompt(
             "Enter unit (e.g., 'oz', 'times', 'pages', leave blank if none)", default="")
 


### PR DESCRIPTION
Fixed AttributeError in Goal Creation

  The issue has been successfully resolved. The problem was that goal creation code was mixing dictionary and object attribute access patterns.

  Root Cause:
  - Goals were initialized as dictionaries (goal: Dict[str, Any] = {...})
  - But the code was trying to set attributes using dot notation (goal.amount = ...)
  - This caused AttributeError: 'dict' object has no attribute 'amount'

  Files Fixed:
  1. lifelog/utils/goal_util.py: Lines 129, 140, 156, 161
  2. lifelog/ui_views/trackers_ui.py: Lines in create_goal_interactive_tui() function

  Changes Made:
  - Changed goal.amount = value to goal["amount"] = value
  - Changed goal.amount = True to goal["amount"] = True
  - Changed goal.amount = float(...) to goal["amount"] = float(...)

  Affected Goal Types: sum, count, reduction, duration, bool, replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive goal creation now consistently saves amounts, units, and behavior fields across all goal types (boolean, replacement, duration, sum/count/reduction, and range).
  * Numeric inputs are normalized (e.g., coerced to numbers) with sensible defaults applied when values are missing, reducing errors and inconsistent data.

* **Refactor**
  * Standardized internal handling of goal fields for more reliable input processing in the interactive interface, without changing any user-facing commands or options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->